### PR TITLE
Attempt to fix #2 again

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,5 +2,3 @@
 make -j ${CPU_COUNT}
 make check
 make install
-cat /proc/cpuinfo
-uname -a

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,4 +1,4 @@
-./configure --prefix=${PREFIX} --with-blas=openblas LDFLAGS="-L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib" CXXFLAGS='-march=x86-64 -mtune=generic -g -O2 -fopenmp'
+./configure --prefix=${PREFIX} --with-blas=openblas LDFLAGS="-L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib" CXXFLAGS='-mno-sse2 -mno-avx -g -O2 -fopenmp'
 make -j ${CPU_COUNT}
 make check
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,4 +1,4 @@
-./configure --prefix=${PREFIX} --with-blas=openblas LDFLAGS="-L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib" CXXFLAGS='-mno-sse2 -mno-avx -g -O2 -fopenmp'
+./configure --prefix=${PREFIX} --with-blas=openblas LDFLAGS="-L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib" CXXFLAGS='-DADEPT_DOUBLE_PACKET_SIZE=1 -DADEPT_FLOAT_PACKET_SIZE=1 -g -O2 -fopenmp'
 make -j ${CPU_COUNT}
 make check
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,3 +2,5 @@
 make -j ${CPU_COUNT}
 make check
 make install
+cat /proc/cpuinfo
+uname -a

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "Adept" %}
 {% set version = "2.0.5" %}
-{% set build_number = "2" %}
+{% set build_number = "3" %}
 {% set sha256 = "6e5e4b29d3a983c97ae0d120c73bba2dded3cac4802e282b097c8bb2f52c43a3" %}
 
 package:


### PR DESCRIPTION
This time, simply disable avx / sse2, via the `-mno-sse2 -mno-avx` flags, we may be able to provide AVX/SSE specific builds [using this](https://github.com/jjhelmus/selectable_pkg_variants_example)